### PR TITLE
feat: add font feature settings support

### DIFF
--- a/.changeset/six-paws-tie.md
+++ b/.changeset/six-paws-tie.md
@@ -1,0 +1,7 @@
+---
+"@react-pdf/textkit": minor
+"@react-pdf/layout": minor
+"@react-pdf/types": minor
+---
+
+Add support for fontFeatureSettings to customise ligatures, tabular number display, and other font features

--- a/.changeset/six-paws-tie.md
+++ b/.changeset/six-paws-tie.md
@@ -4,4 +4,4 @@
 "@react-pdf/types": minor
 ---
 
-Add support for fontFeatureSettings to customise ligatures, tabular number display, and other font features
+Add support for fontFeatureSettings to customize ligatures, tabular number display, and other font features

--- a/packages/examples/vite/src/examples/font-feature-settings/index.jsx
+++ b/packages/examples/vite/src/examples/font-feature-settings/index.jsx
@@ -1,0 +1,86 @@
+/* eslint react/prop-types: 0 */
+/* eslint react/jsx-sort-props: 0 */
+
+import { Document, Font, Page, StyleSheet, Text } from '@react-pdf/renderer';
+import React from 'react';
+
+import RobotoFont from '../../../public/Roboto-Regular.ttf';
+import RubikFont from '../../../public/Rubik-Regular.ttf';
+
+const styles = StyleSheet.create({
+  body: {
+    paddingTop: 35,
+    paddingBottom: 45,
+    paddingHorizontal: 35,
+    position: 'relative',
+    fontSize: 14,
+  },
+  headline: {
+    fontFamily: 'Roboto',
+    fontSize: '24',
+    paddingVertical: 12,
+  },
+  rubik: {
+    fontFamily: 'Rubik',
+  },
+  roboto: {
+    fontFamily: 'Roboto',
+  },
+  tabular: {
+    fontFeatureSettings: ['tnum'],
+  },
+  smallCapitals: {
+    fontFeatureSettings: ['smcp'],
+  },
+  disableCommonLigatures: {
+    fontFeatureSettings: { liga: 0 },
+  },
+});
+
+Font.register({
+  family: 'Rubik',
+  fonts: [{ src: RubikFont, fontWeight: 400 }],
+});
+Font.register({
+  family: 'Roboto',
+  fonts: [{ src: RobotoFont, fontWeight: 400 }],
+});
+
+const MyDoc = () => {
+  const longNumberExample = "012'345'678'901";
+  const commonLigaturesExample = 'A firefighter from Sheffield';
+  return (
+    <Page style={styles.body}>
+      <Text style={styles.headline}>Rubik</Text>
+      <Text style={styles.rubik}>{longNumberExample} – Default features</Text>
+      <Text style={[styles.rubik, styles.tabular]}>
+        {longNumberExample} – Tabular numbers
+      </Text>
+      <Text style={styles.headline}>Roboto</Text>
+      <Text style={styles.roboto}>
+        {commonLigaturesExample} – Default features
+      </Text>
+      <Text style={[styles.roboto, styles.disableCommonLigatures]}>
+        {commonLigaturesExample} – Common ligatures off
+      </Text>
+      <Text style={[styles.roboto, styles.smallCapitals]}>
+        {commonLigaturesExample} – Small capitals
+      </Text>
+    </Page>
+  );
+};
+
+const FontFeatureSettings = () => {
+  return (
+    <Document>
+      <MyDoc />
+    </Document>
+  );
+};
+
+export default {
+  id: 'font-feature-settings',
+  name: 'Font Feature Settings',
+  description: '',
+  Document: FontFeatureSettings,
+};

--- a/packages/examples/vite/src/examples/font-feature-settings/index.jsx
+++ b/packages/examples/vite/src/examples/font-feature-settings/index.jsx
@@ -17,7 +17,7 @@ const styles = StyleSheet.create({
   },
   headline: {
     fontFamily: 'Roboto',
-    fontSize: '24',
+    fontSize: 24,
     paddingVertical: 12,
   },
   rubik: {

--- a/packages/examples/vite/src/examples/index.js
+++ b/packages/examples/vite/src/examples/index.js
@@ -2,7 +2,9 @@ import duplicatedImages from './duplicated-images';
 import ellipsis from './ellipsis';
 import emoji from './emoji';
 import fontFamilyFallback from './font-family-fallback';
+import fontFeatureSettings from './font-feature-settings';
 import fontWeight from './font-weight';
+import forms from './forms';
 import fractals from './fractals';
 import goTo from './go-to';
 import imageStressTest from './image-stress-test';
@@ -18,7 +20,6 @@ import resume from './resume';
 import svg from './svg';
 import svgTransform from './svg-transform';
 import transformOrigin from './transform-origin';
-import forms from './forms';
 
 const EXAMPLES = [
   duplicatedImages,
@@ -26,6 +27,7 @@ const EXAMPLES = [
   emoji,
   fontFamilyFallback,
   fontWeight,
+  fontFeatureSettings,
   fractals,
   goTo,
   JpgOrientation,

--- a/packages/examples/vite/src/index.jsx
+++ b/packages/examples/vite/src/index.jsx
@@ -1,8 +1,8 @@
 import './index.css';
 
+import { PDFViewer } from '@react-pdf/renderer';
 import React, { useEffect, useState } from 'react';
 import { createRoot } from 'react-dom/client';
-import { PDFViewer } from '@react-pdf/renderer';
 
 import EXAMPLES from './examples';
 

--- a/packages/layout/src/steps/resolveInheritance.js
+++ b/packages/layout/src/steps/resolveInheritance.js
@@ -7,6 +7,7 @@ const BASE_INHERITABLE_PROPERTIES = [
   'fontSize',
   'fontStyle',
   'fontWeight',
+  'fontFeatureSettings',
   'letterSpacing',
   'opacity',
   'textDecoration',

--- a/packages/layout/src/svg/inheritProps.js
+++ b/packages/layout/src/svg/inheritProps.js
@@ -22,6 +22,7 @@ const BASE_SVG_INHERITED_PROPS = [
   'fontSize',
   'fontStyle',
   'fontWeight',
+  'fontFeatureSettings',
   'letterSpacing',
   'opacity',
   'textDecoration',

--- a/packages/layout/src/text/getAttributedString.js
+++ b/packages/layout/src/text/getAttributedString.js
@@ -32,6 +32,7 @@ const getFragments = (fontStore, instance, parentLink, level = 0) => {
     fontWeight,
     fontStyle,
     fontSize = 18,
+    fontFeatureSettings,
     textAlign,
     lineHeight,
     textDecoration,
@@ -83,6 +84,7 @@ const getFragments = (fontStore, instance, parentLink, level = 0) => {
     underlineColor: textDecorationColor || color,
     link: parentLink || instance.props?.src || instance.props?.href,
     align: textAlign || (direction === 'rtl' ? 'right' : 'left'),
+    features: fontFeatureSettings,
   };
 
   for (let i = 0; i < instance.children.length; i += 1) {

--- a/packages/layout/tests/steps/resolveInhritance.test.js
+++ b/packages/layout/tests/steps/resolveInhritance.test.js
@@ -154,4 +154,8 @@ describe('layout resolveInheritance', () => {
   test('Should inherit textAlign value', shouldInherit('textAlign'));
   test('Should inherit visibility value', shouldInherit('visibility'));
   test('Should inherit wordSpacing value', shouldInherit('wordSpacing'));
+  test(
+    'Should inherit fontFeatureSettings value',
+    shouldInherit('fontFeatureSettings'),
+  );
 });

--- a/packages/stylesheet/src/types.ts
+++ b/packages/stylesheet/src/types.ts
@@ -321,13 +321,44 @@ export type TextTransform =
 
 export type VerticalAlign = 'sub' | 'super';
 
+export type FontFeatureSetting =
+  | 'liga'
+  | 'dlig'
+  | 'onum'
+  | 'lnum'
+  | 'tnum'
+  | 'zero'
+  | 'frac'
+  | 'sups'
+  | 'subs'
+  | 'smcp'
+  | 'c2sc'
+  | 'case'
+  | 'hlig'
+  | 'calt'
+  | 'swsh'
+  | 'hist'
+  | 'ss**'
+  | 'kern'
+  | 'locl'
+  | 'rlig'
+  | 'medi'
+  | 'init'
+  | 'isol'
+  | 'fina'
+  | 'mark'
+  | 'mkmk';
+export type FontFeatureSettings =
+  | FontFeatureSetting[]
+  | Record<FontFeatureSetting, number>;
+
 export type TextStyle = {
   direction?: 'ltr' | 'rtl';
   fontSize?: number | string;
   fontFamily?: string | string[];
   fontStyle?: FontStyle;
   fontWeight?: FontWeight;
-  fontFeatureSettings?: string[] | Record<string, boolean>;
+  fontFeatureSettings?: FontFeatureSettings;
   letterSpacing?: number | string;
   lineHeight?: number | string;
   maxLines?: number;
@@ -348,6 +379,7 @@ export type TextSafeStyle = TextExpandedStyle & {
   fontWeight?: number;
   letterSpacing?: number;
   lineHeight?: number;
+  fontFeatureSettings?: FontFeatureSettings;
 };
 
 // Margins

--- a/packages/stylesheet/src/types.ts
+++ b/packages/stylesheet/src/types.ts
@@ -284,6 +284,7 @@ export type TextStyle = {
   fontFamily?: string | string[];
   fontStyle?: FontStyle;
   fontWeight?: FontWeight;
+  fontFeatureSettings?: string[] | Record<string, boolean>;
   letterSpacing?: number | string;
   lineHeight?: number | string;
   maxLines?: number;

--- a/packages/textkit/src/layout/generateGlyphs.ts
+++ b/packages/textkit/src/layout/generateGlyphs.ts
@@ -42,7 +42,7 @@ const layoutRun = (string: string) => {
    */
   return (run: Run) => {
     const { start, end, attributes = {} } = run;
-    const { font } = attributes;
+    const { font, features } = attributes;
 
     if (!font) return { ...run, glyphs: [], glyphIndices: [], positions: [] };
 
@@ -53,7 +53,7 @@ const layoutRun = (string: string) => {
     // passing LTR To force fontkit to not reverse the string
     const glyphRun = font.layout(
       runString,
-      undefined,
+      features,
       undefined,
       undefined,
       'ltr',

--- a/packages/textkit/src/types.ts
+++ b/packages/textkit/src/types.ts
@@ -51,7 +51,7 @@ export type Attributes = {
   characterSpacing?: number;
   color?: string;
   direction?: 'rtl' | 'ltr';
-  features?: unknown[];
+  features?: string[] | Record<string, number>;
   fill?: boolean;
   font?: Font[];
   fontSize?: number;

--- a/packages/textkit/src/types.ts
+++ b/packages/textkit/src/types.ts
@@ -1,5 +1,6 @@
 import type { Glyph as FontkitGlyph } from 'fontkit';
 import type { Font } from '@rpdf/font';
+import type { FontFeatureSettings } from '@rpdf/stylesheet';
 import { Factor as JustificationFactor } from './engines/justification/types';
 
 export type Coordinate = {
@@ -51,7 +52,7 @@ export type Attributes = {
   characterSpacing?: number;
   color?: string;
   direction?: 'rtl' | 'ltr';
-  features?: string[] | Record<string, number>;
+  features?: FontFeatureSettings;
   fill?: boolean;
   font?: Font[];
   fontSize?: number;


### PR DESCRIPTION
Implements diegomura/react-pdf#2155. Adds the fontFeatureSettings style property for CSS equivalent support. Takes a list of feature tags which appends to the default set, or an object to turn on/off individual features, as supported by fontkit.

Allows users to apply font features like tabular numbers, fractions, alternate glyphs, control over ligatures, etc.

Thanks to @stefanwittwer [#2740](https://github.com/diegomura/react-pdf/pull/2740)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for advanced font feature settings (such as ligatures, tabular numbers, and small capitals) in PDF rendering.
  - Introduced a new example demonstrating the use of font feature settings with custom fonts.

- **Bug Fixes**
  - Ensured font feature settings are properly inherited and applied to text and SVG elements.

- **Tests**
  - Added tests to verify correct inheritance of font feature settings.

- **Style**
  - Improved formatting of CSS utility classes in the example viewer interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->